### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ A Model Context Protocol (MCP) server that connects your TeslaMate database to A
 - 🔒 **Optional Authentication** - Bearer token support for remote deployments
 - 🏗️ **Modular Architecture** - Clean, maintainable codebase
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/cobanov-teslamate-mcp).
+
 ## Prerequisites
 
 - [TeslaMate](https://github.com/teslamate-org/teslamate) running with PostgreSQL


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/cobanov-teslamate-mcp).