### PR TITLE
[codex] Fix FastMCP context argument schemas

### DIFF
--- a/src/teslamate_mcp/tools/custom_sql.py
+++ b/src/teslamate_mcp/tools/custom_sql.py
@@ -101,7 +101,6 @@ def register_custom_sql(
         "`get_database_schema` first to learn the available tables and columns."
     )
 
-    @mcp.tool(name="run_sql", description=description, annotations=annotations)
     async def run_sql(
         ctx: Context,
         query: str = Field(
@@ -126,3 +125,6 @@ def register_custom_sql(
         elapsed_ms = int((time.perf_counter() - start) * 1000)
         await ctx.info(f"run_sql returned {len(rows)} row(s) in {elapsed_ms}ms")
         return rows
+
+    run_sql.__annotations__["ctx"] = Context
+    mcp.tool(name="run_sql", description=description, annotations=annotations)(run_sql)

--- a/src/teslamate_mcp/tools/registry.py
+++ b/src/teslamate_mcp/tools/registry.py
@@ -91,4 +91,5 @@ def _register_one(mcp: FastMCP, tool: PredefinedTool, annotations: ToolAnnotatio
 
     handler.__name__ = tool.name
     handler.__doc__ = tool.description
+    handler.__annotations__["ctx"] = Context
     mcp.tool(name=tool.name, description=tool.description, annotations=annotations)(handler)

--- a/src/teslamate_mcp/tools/schema_tool.py
+++ b/src/teslamate_mcp/tools/schema_tool.py
@@ -32,11 +32,6 @@ def register_schema_tool(mcp: FastMCP) -> None:
         "writing custom SQL with `run_sql`."
     )
 
-    @mcp.tool(
-        name="get_database_schema",
-        description=description,
-        annotations=annotations,
-    )
     async def get_database_schema(ctx: Context) -> list[dict[str, Any]]:
         lifespan_ctx = ctx.request_context.lifespan_context
         if lifespan_ctx.schema is None:
@@ -44,3 +39,10 @@ def register_schema_tool(mcp: FastMCP) -> None:
             lifespan_ctx.schema = await load_schema(lifespan_ctx.pool)
         await ctx.info(f"Returning schema for {len(lifespan_ctx.schema)} columns")
         return lifespan_ctx.schema
+
+    get_database_schema.__annotations__["ctx"] = Context
+    mcp.tool(
+        name="get_database_schema",
+        description=description,
+        annotations=annotations,
+    )(get_database_schema)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from teslamate_mcp.config import Settings
+from teslamate_mcp.server import create_server
 from teslamate_mcp.tools.registry import discover_predefined_tools
 
 
@@ -37,3 +39,21 @@ def test_malformed_sidecar_raises(tmp_path: Path) -> None:
     (tmp_path / "q.toml").write_text('name = "x"\n', encoding="utf-8")  # missing description
     with pytest.raises(ValueError, match="description"):
         discover_predefined_tools(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_tool_schemas_do_not_expose_context_argument() -> None:
+    settings = Settings(database_url="postgresql://teslamate:secret@example.test/teslamate")  # type: ignore[call-arg]
+    mcp = create_server(settings)
+
+    tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+    for name in [
+        "get_basic_car_information",
+        "get_database_schema",
+        "run_sql",
+    ]:
+        schema = tools[name].inputSchema
+        assert "ctx" not in schema.get("properties", {})
+        assert "ctx" not in schema.get("required", [])
+    assert tools["run_sql"].inputSchema["required"] == ["query"]


### PR DESCRIPTION
## Summary

Fix FastMCP tool registration so internal `Context` parameters are injected by the MCP server instead of being exposed as client-facing tool arguments.

## Root Cause

The project uses `from __future__ import annotations`, so `ctx: Context` was stored as a postponed annotation string at runtime. FastMCP detects context parameters from the runtime annotation before building the tool input schema, so `ctx` was incorrectly included as a required MCP argument. Clients then failed tool calls with `ctx Field required`.

## Changes

- Normalize `ctx` annotations to the runtime `Context` type before registering predefined tools, `get_database_schema`, and `run_sql`.
- Convert decorator-based registrations where needed so the annotation fix happens before FastMCP builds schemas.
- Add a regression test proving `ctx` is absent from client-facing tool schemas while `run_sql` still requires `query`.

## Validation

- `uv run ruff check src tests`
- `uv run pytest`